### PR TITLE
Hotfix for Enemy class compile error.

### DIFF
--- a/src/main/java/hu/unideb/inf/factory/EnemyCreationService.java
+++ b/src/main/java/hu/unideb/inf/factory/EnemyCreationService.java
@@ -6,7 +6,7 @@ public class EnemyCreationService implements EntityFactory {
 
     @Override
     public Enemy create() {
-        return new Enemy();
+        return Enemy.builder().build();
     }
 
 }

--- a/src/main/java/hu/unideb/inf/model/Enemy.java
+++ b/src/main/java/hu/unideb/inf/model/Enemy.java
@@ -1,10 +1,11 @@
 package hu.unideb.inf.model;
 
-import lombok.Builder;
 import lombok.Data;
+import lombok.experimental.SuperBuilder;
 
-@Builder
+
 @Data
+@SuperBuilder
 public class Enemy extends Entity {
 
     private Weapon weaponDrop;


### PR DESCRIPTION
The compiler will throw errors because of EnemyCreationService class.
Therefore we cannot work with the current main branch, because even
unit tests cannot be run because of the compile errors.

This commit does three simple things:
- Changes Enemy from using Builder to SuperBuilder
- Rearranges the declaration order of Data and SuperBuilder annotations
- Changes EnemyCreationService to call the builder instead of new operator.